### PR TITLE
Implement ResponseCodeMatchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,116 @@
 # ResponseCodeMatchers
 
-TODO: Write a gem description
+Provide rspec matchers to match http response code.  
+The receiver of this matcher should have `#code` method which returns http status code.
 
 ## Installation
-
-Add this line to your application's Gemfile:
-
-    gem 'response_code_matchers'
-
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install response_code_matchers
+```
+$ gem install response_code_matchers
+```
 
 ## Usage
+In Rails example:
 
-TODO: Write usage instructions here
+```ruby
+# spec/spec_helper.rb
+require "response_code_matchers"
 
-## Contributing
+RSpec.configure do |config|
+  config.include ResponseCodeMatchers
+end
+```
 
-1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+```ruby
+# spec/controllers/blogs_controller.rb
+describe BlogsController do
+  describe "#create" do
+    subject do
+      post :create, params
+    end
+
+    let(:params) do
+      { :title => "title", :body => "body", :token => "token", :user_id => 1 }
+    end
+
+    # 201
+    context "with valid token" do
+      it { should be_created }
+    end
+
+    # 400
+    context "without user_id" do
+      before do
+        params.delete(:user_id)
+      end
+
+      it { should be_bad_request }
+    end
+
+    # 401
+    context "with invalid token" do
+      before do
+        params[:token] = "invalid"
+      end
+
+      it { should be_unauthorized }
+    end
+  end
+end
+```
+
+
+## Matchers
+```ruby
+100: response.should be_continue
+101: response.should be_switching_protocols
+102: response.should be_processing
+200: response.should be_ok
+201: response.should be_created
+202: response.should be_accepted
+203: response.should be_non_authoritative_information
+204: response.should be_no_content
+205: response.should be_reset_content
+206: response.should be_partial_content
+207: response.should be_multi_status
+226: response.should be_im_used
+300: response.should be_multiple_choices
+301: response.should be_moved_permanently
+302: response.should be_found
+303: response.should be_see_other
+304: response.should be_not_modified
+305: response.should be_use_proxy
+306: response.should be_reserved
+307: response.should be_temporary_redirect
+400: response.should be_bad_request
+401: response.should be_unauthorized
+402: response.should be_payment_required
+403: response.should be_forbidden
+404: response.should be_not_found
+405: response.should be_method_not_allowed
+406: response.should be_not_acceptable
+407: response.should be_proxy_authentication_required
+408: response.should be_request_timeout
+409: response.should be_conflict
+410: response.should be_gone
+411: response.should be_length_required
+412: response.should be_precondition_failed
+413: response.should be_request_entity_too_large
+414: response.should be_request_uri_too_long
+415: response.should be_unsupported_media_type
+416: response.should be_requested_range_not_satisfiable
+417: response.should be_expectation_failed
+418: response.should be_im_a_teapot
+422: response.should be_unprocessable_entity
+423: response.should be_locked
+424: response.should be_failed_dependency
+426: response.should be_upgrade_required
+500: response.should be_internal_server_error
+501: response.should be_not_implemented
+502: response.should be_bad_gateway
+503: response.should be_service_unavailable
+504: response.should be_gateway_timeout
+505: response.should be_http_version_not_supported
+506: response.should be_variant_also_negotiates
+507: response.should be_insufficient_storage
+510: response.should be_not_extended
+```

--- a/lib/response_code_matchers.rb
+++ b/lib/response_code_matchers.rb
@@ -1,5 +1,35 @@
 require "response_code_matchers/version"
+require "rack"
 
 module ResponseCodeMatchers
-  # Your code goes here...
+  Rack::Utils::SYMBOL_TO_STATUS_CODE.each do |name, code|
+    name = name.to_s.gsub("'", "")
+    define_method("be_#{name}") do
+      ResponseCodeMatcher.new(code.to_s, name)
+    end
+  end
+
+  class ResponseCodeMatcher
+    def initialize(expected, name)
+      @expected    = expected
+      @description = name.to_s.gsub("_", " ")
+    end
+
+    def matches?(response)
+      @actual = response.code
+      @actual == @expected
+    end
+
+    def description
+      "be #@description"
+    end
+
+    def failure_message
+      "expected response code to be #@expected, but #@actual"
+    end
+
+    def negative_failure_message
+      "expected response code not to be #@expected, but #@actual"
+    end
+  end
 end

--- a/response_code_matchers.gemspec
+++ b/response_code_matchers.gemspec
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# encoding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'response_code_matchers/version'
@@ -7,13 +7,16 @@ Gem::Specification.new do |gem|
   gem.name          = "response_code_matchers"
   gem.version       = ResponseCodeMatchers::VERSION
   gem.authors       = ["Ryo NAKAMURA"]
-  gem.email         = ["ryo-nakamura@cookpad.com"]
-  gem.description   = %q{TODO: Write a gem description}
-  gem.summary       = %q{TODO: Write a gem summary}
-  gem.homepage      = ""
+  gem.email         = ["r7kamura@gmail.com"]
+  gem.description   = "Provide rspec matchers to match http response code"
+  gem.summary       = "RSpec utility matchers for http response code"
+  gem.homepage      = "https://github.com/r7kamura/response_code_matchers"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
+
+  gem.add_dependency "rack"
+  gem.add_development_dependency "rspec"
 end

--- a/spec/response_code_matchers_spec.rb
+++ b/spec/response_code_matchers_spec.rb
@@ -1,0 +1,68 @@
+require "spec_helper"
+
+describe ResponseCodeMatchers do
+  %w[
+    100 be_continue
+    101 be_switching_protocols
+    102 be_processing
+    200 be_ok
+    201 be_created
+    202 be_accepted
+    203 be_non_authoritative_information
+    204 be_no_content
+    205 be_reset_content
+    206 be_partial_content
+    207 be_multi_status
+    226 be_im_used
+    300 be_multiple_choices
+    301 be_moved_permanently
+    302 be_found
+    303 be_see_other
+    304 be_not_modified
+    305 be_use_proxy
+    306 be_reserved
+    307 be_temporary_redirect
+    400 be_bad_request
+    401 be_unauthorized
+    402 be_payment_required
+    403 be_forbidden
+    404 be_not_found
+    405 be_method_not_allowed
+    406 be_not_acceptable
+    407 be_proxy_authentication_required
+    408 be_request_timeout
+    409 be_conflict
+    410 be_gone
+    411 be_length_required
+    412 be_precondition_failed
+    413 be_request_entity_too_large
+    414 be_request_uri_too_long
+    415 be_unsupported_media_type
+    416 be_requested_range_not_satisfiable
+    417 be_expectation_failed
+    418 be_im_a_teapot
+    422 be_unprocessable_entity
+    423 be_locked
+    424 be_failed_dependency
+    426 be_upgrade_required
+    500 be_internal_server_error
+    501 be_not_implemented
+    502 be_bad_gateway
+    503 be_service_unavailable
+    504 be_gateway_timeout
+    505 be_http_version_not_supported
+    506 be_variant_also_negotiates
+    507 be_insufficient_storage
+    510 be_not_extended
+  ].each_slice(2) do |code, matcher|
+    describe "##{matcher}" do
+      let(:response) do
+        mock(:code => code)
+      end
+
+      it "matches http response code #{code}" do
+        response.should send(matcher)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+require "response_code_matchers"
+
+RSpec.configure do |config|
+  config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.run_all_when_everything_filtered = true
+  config.filter_run :focus
+
+  config.include ResponseCodeMatchers
+end


### PR DESCRIPTION
# ResponseCodeMatchers

Provide rspec matchers to match http response code.  
The receiver of this matcher should have `#code` method which returns http status code.
## Installation

```
$ gem install response_code_matchers
```
## Usage

In Rails example:

``` ruby
# spec/spec_helper.rb
require "response_code_matchers"

RSpec.configure do |config|
  config.include ResponseCodeMatchers
end
```

``` ruby
# spec/controllers/blogs_controller.rb
describe BlogsController do
  describe "#create" do
    subject do
      post :create, params
    end

    let(:params) do
      { :title => "title", :body => "body", :token => "token", :user_id => 1 }
    end

    #201
    context "with valid token" do
      it { should be_created }
    end

    #400
    context "without user_id" do
      before do
        params.delete(:user_id)
      end

      it { should be_bad_request }
    end

    #401
    context "with invalid token" do
      before do
        params[:token] = "invalid"
      end

      it { should be_unauthorized }
    end
  end
end
```
## Matchers

``` ruby
100: response.should be_continue
101: response.should be_switching_protocols
102: response.should be_processing
200: response.should be_ok
201: response.should be_created
202: response.should be_accepted
203: response.should be_non_authoritative_information
204: response.should be_no_content
205: response.should be_reset_content
206: response.should be_partial_content
207: response.should be_multi_status
226: response.should be_im_used
300: response.should be_multiple_choices
301: response.should be_moved_permanently
302: response.should be_found
303: response.should be_see_other
304: response.should be_not_modified
305: response.should be_use_proxy
306: response.should be_reserved
307: response.should be_temporary_redirect
400: response.should be_bad_request
401: response.should be_unauthorized
402: response.should be_payment_required
403: response.should be_forbidden
404: response.should be_not_found
405: response.should be_method_not_allowed
406: response.should be_not_acceptable
407: response.should be_proxy_authentication_required
408: response.should be_request_timeout
409: response.should be_conflict
410: response.should be_gone
411: response.should be_length_required
412: response.should be_precondition_failed
413: response.should be_request_entity_too_large
414: response.should be_request_uri_too_long
415: response.should be_unsupported_media_type
416: response.should be_requested_range_not_satisfiable
417: response.should be_expectation_failed
418: response.should be_im_a_teapot
422: response.should be_unprocessable_entity
423: response.should be_locked
424: response.should be_failed_dependency
426: response.should be_upgrade_required
500: response.should be_internal_server_error
501: response.should be_not_implemented
502: response.should be_bad_gateway
503: response.should be_service_unavailable
504: response.should be_gateway_timeout
505: response.should be_http_version_not_supported
506: response.should be_variant_also_negotiates
507: response.should be_insufficient_storage
510: response.should be_not_extended
```
