### PR TITLE
Add support for Rack::MockResponse

### DIFF
--- a/lib/response_code_matchers.rb
+++ b/lib/response_code_matchers.rb
@@ -3,15 +3,11 @@ require "rack"
 
 module ResponseCodeMatchers
 
-  def status_name(name)
-
-  end
-
   Rack::Utils::SYMBOL_TO_STATUS_CODE.each do |name, code|
     name = name.to_s.tap do |t|
-      t.gsub!("'", '')
-      t.gsub!(/\(.*\)/, '')
-      t.gsub!(/\_$/, '')
+      t.gsub!("'", '')      # remove single quotes
+      t.gsub!(/\(.*\)/, '') # remove anything in parentheses
+      t.gsub!(/\_$/, '')    # remove trailing underscores
     end
     define_method("be_#{name}") do
       ResponseCodeMatcher.new(code.to_s, name)

--- a/spec/response_code_matchers_spec.rb
+++ b/spec/response_code_matchers_spec.rb
@@ -40,7 +40,6 @@ describe ResponseCodeMatchers do
     415 be_unsupported_media_type
     416 be_requested_range_not_satisfiable
     417 be_expectation_failed
-    418 be_im_a_teapot
     422 be_unprocessable_entity
     423 be_locked
     424 be_failed_dependency


### PR DESCRIPTION
I was having issues getting this to work in my tests. Reason being is that `Rack::MockResponse` does not respond to `#code` but instead to `#status`. Both implementations are now supported. 

While running tests, I found two broken test cases and fixed those as well.
