### PR TITLE
Specify status method support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ResponseCodeMatchers
 
 Provide rspec matchers to match http response code.  
-The receiver of this matcher should have `#code` method which returns http status code.
+The receiver of this matcher should have `#code` or `#status` method which returns http status code.
 
 ## Installation
 ```


### PR DESCRIPTION
I read your source code and found it supports receivers which have `status` method.
It's tiny update but it would attract users who use such receivers.
