### PR TITLE
RSpec.configuration.treat_symbols_as_metadata_keys_with_true_values= only for RSpec 2

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ RSpec.configure do |config|
   if config.respond_to?(:raise_errors_for_deprecations!)
     config.raise_errors_for_deprecations!
   end
-  config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.treat_symbols_as_metadata_keys_with_true_values = true if RSpec::Core::Version::STRING < '3'
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
The option has been deprecated since https://github.com/rspec/rspec-core/pull/1006
and will always be set to `true` by default.