### PR TITLE
Response should respond_to :header and :body as well

### DIFF
--- a/lib/response_code_matchers.rb
+++ b/lib/response_code_matchers.rb
@@ -21,6 +21,8 @@ module ResponseCodeMatchers
     end
 
     def matches?(response)
+      return response.__send__(method_name) unless response.respond_to?(:header) && response.respond_to?(:body)
+
       if @valid = response.respond_to?(:code)
         @actual = response.code
         @actual == @expected

--- a/lib/response_code_matchers.rb
+++ b/lib/response_code_matchers.rb
@@ -20,17 +20,17 @@ module ResponseCodeMatchers
       @name     = name
     end
 
-    def matches?(response)
-      return response.__send__(method_name) unless response.respond_to?(:header) && response.respond_to?(:body)
+    def matches?(obj)
+      return obj.__send__(method_name) unless obj.respond_to?(:header) && obj.respond_to?(:body)
 
-      if @valid = response.respond_to?(:code)
-        @actual = response.code
+      if @valid = obj.respond_to?(:code)
+        @actual = obj.code
         @actual == @expected
-      elsif @valid = response.respond_to?(:status)
-        @actual = response.status.to_s
+      elsif @valid = obj.respond_to?(:status)
+        @actual = obj.status.to_s
         @actual == @expected
       else
-        response.__send__(method_name)
+        obj.__send__(method_name)
       end
     end
 

--- a/spec/response_code_matchers_spec.rb
+++ b/spec/response_code_matchers_spec.rb
@@ -56,7 +56,7 @@ describe ResponseCodeMatchers do
   ].each_slice(2) do |code, matcher|
     describe "##{matcher}" do
       let(:response) do
-        double(:code => code)
+        double(:code => code, :header => [], :body => "")
       end
 
       it "matches http response code #{code}" do
@@ -67,7 +67,7 @@ describe ResponseCodeMatchers do
 
   context "when receiver responds to #status" do
     let(:receiver) do
-      double(:status => 406)
+      double(:status => 406, :header => [], :body => "")
     end
 
     it "calls original receiver.xxx?" do
@@ -77,7 +77,7 @@ describe ResponseCodeMatchers do
 
   context "when receiver does not have a method #code" do
     let(:receiver) do
-      double(:accepted? => true)
+      double(:accepted? => true, :header => [], :body => "")
     end
 
     it "calls original receiver.xxx?" do


### PR DESCRIPTION
response_code_matchers regards any object that responds_to :code or **any object that responds_to :status** as a response-ish object.

But, such objects would actually quite commonly exist in our systems, you know, and unit tests on such objects would occasionally  report weird errors like
`expected response code to be 202, but accepted`.